### PR TITLE
fix(cd): repair image URL reference in deploy step

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -113,8 +113,11 @@ jobs:
     - name: Deploy to Cloud Run
       id: deploy
       run: |
+        IMAGE_URL="${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.SERVICE_NAME }}:${{ github.sha }}"
+        echo "Deploying image: $IMAGE_URL"
+        
         gcloud run deploy ${{ env.SERVICE_NAME }} \
-          --image ${{ needs.build-and-push.outputs.image-url }} \
+          --image $IMAGE_URL \
           --platform managed \
           --region ${{ env.REGION }} \
           --allow-unauthenticated \


### PR DESCRIPTION
- Fix empty --image argument in gcloud run deploy
- Use direct environment variable construction instead of job outputs
- Add debug logging to show which image is being deployed
- This should resolve the 'expected one argument' error

# Pull Request

## 📝 Description
Brief description of the changes in this PR.

## 🔄 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements

## 🧪 Testing
- [ ] Tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested the Docker container builds and runs correctly

## 📋 Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## 🔗 Related Issues
Fixes #(issue number)

## 📸 Screenshots (if applicable)
Add screenshots to help explain your changes.

## 🚀 Deployment Notes
Any special deployment considerations or migration steps needed.

## 📊 Performance Impact
Describe any performance implications of your changes.

## 🔒 Security Considerations
Describe any security implications of your changes.
